### PR TITLE
chore: #48 - Test: Path Extraction Fix for Issue #45

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -5,7 +5,7 @@
       "args": [
         "-y",
         "@anaisbetts/mcp-playwright@latest",
-        "/Users/Warmonger0/tac/tac-7/trees/26e44bd2/playwright-mcp-config.json"
+        "/Users/Warmonger0/tac/tac-7/trees/396d3960/playwright-mcp-config.json"
       ]
     }
   }

--- a/playwright-mcp-config.json
+++ b/playwright-mcp-config.json
@@ -6,7 +6,7 @@
     },
     "contextOptions": {
       "recordVideo": {
-        "dir": "./videos",
+        "dir": "/Users/Warmonger0/tac/tac-7/trees/396d3960/videos",
         "size": {
           "width": 1920,
           "height": 1080


### PR DESCRIPTION
## Summary
This PR tests the path extraction fix implemented for Issue #45. The fix ensures that ADW planning agents return only the absolute path without any commentary, preventing path extraction failures.

## Implementation Plan
[specs/issue-48-adw-396d3960-sdlc_planner-test-path-extraction-fix.md](specs/issue-48-adw-396d3960-sdlc_planner-test-path-extraction-fix.md)

## Changes
- Updated worktree paths in `.mcp.json` and `playwright-mcp-config.json` configuration files

## Purpose
Validate that ADW planning agents now return ONLY the absolute path without any commentary, preventing path extraction failures.

## Expected Behavior
- Agent executes: `PLAN_FILE=$(ls specs/issue-...) && echo "$(pwd)/$PLAN_FILE"`
- Returns: `/Users/Warmonger0/tac/tac-7/trees/{adw_id}/specs/issue-{number}-adw-{adw_id}-sdlc_planner-test-path-extraction-fix.md`
- No commentary, just the path

Closes #48

ADW ID: 396d3960